### PR TITLE
fix: correct Industry Flag Service initial configuration

### DIFF
--- a/IndustryFlagService/backend/config/configuration.yml
+++ b/IndustryFlagService/backend/config/configuration.yml
@@ -74,18 +74,16 @@ edc:
   url: "https://TODO___XXX__YOUR_URL___XXX"
   apis:
     readiness: "/api/check/readiness"
-    catalog: "/control/data/v3/catalog/request"
-    edr_prefix: "/control/data/v2/edrs"
+    catalog: "/management/v3/catalog/request"
+    edr_prefix: "/management/v2/edrs"
     view_edr: "/request"
     transfer_edr: "/dataaddress?auto_refresh=true"
-    dsp: "/control/api/v1/dsp"
+    dsp: "/api/v1/dsp"
 
   oauth:
-    token_url: "https://TODO___XXX__YOUR_URL___XXX"
-    client_id: "TODO___XXX___YOUR_ID___XXX"
-    client_secret: "TODO___XXX___YOUR_SECRET___XXX"
+    apiKey: "TODO___XXX___YOUR_API_KEY___XXX"
 
-  participantId: "BPNL00000009VAL7"
+  participantId: "TODO___XXX___YOUR_BPN___XXX"
   
   dct_type_key: "'http://purl.org/dc/terms/type'.'@id'"
 
@@ -93,13 +91,13 @@ edc:
     expiration_time: 60
 
 discovery:
-  url: "https://discoveryfinder.beta.cofinity-x.com/api/v1.0/administration/connectors/discovery/search"
+  url: "https://TODO___XXX__YOUR_URL___XXX/discoveryfinder/api/v1.0/administration/connectors/discovery/search"
   keys:
-    edc_discovery: "bpnl"
+    edc_discovery: "bpn"
 
 catenax:
   centralidp:
-    url: "https://centralidp.beta.cofinity-x.com/auth/"
+    url: "https://TODO___XXX__YOUR_URL___XXX/auth/"
     realm: CX-Central
-    clientid: "TODO___XXX__YOUR_CLIENTID___XXX"
-    clientsecret: "TODO___XXX___YOUR_CLIENT_SECRET___XXX"
+    client_id: "TODO___XXX__YOUR_CLIENTID___XXX"
+    client_secret: "TODO___XXX___YOUR_CLIENT_SECRET___XXX"

--- a/IndustryFlagService/backend/init.py
+++ b/IndustryFlagService/backend/init.py
@@ -84,7 +84,6 @@ with open('./config/configuration.yml', 'rt') as f:
     app_configuration = yaml.safe_load(f.read())
 
 # Add the previous folder structure to the system path to import the utilities
-sys.path.append("../")
 
 app = FastAPI(title="main")
 
@@ -291,7 +290,7 @@ def init_app(host: str, port: int, log_level: str = "info"):
             "[INIT] It was not possible to connect to the EDC Connector because there was no configuration available")
 
     authManager = AuthManager()
-    auth_instance =SovityAuth()
+
 
     auth_config: dict = app_configuration.get("authorization", {"enabled": False})
     auth_enabled: bool = auth_config.get("enabled", False)
@@ -314,7 +313,7 @@ def init_app(host: str, port: int, log_level: str = "info"):
     while not connected:
         try:
             logger.info("[INIT] Attempting connection to the EDC Connector...")
-            edcService = EdcService(config=edc_config, auth_instance=auth_instance)
+            edcService = EdcService(config=edc_config)
             connected = True
         except Exception as e:
             logger.critical(str(e))
@@ -342,25 +341,20 @@ def init_app(host: str, port: int, log_level: str = "info"):
     if auth_url is None:
         raise Exception("[INIT] No centralidp realm config was specified!")
 
-    clientid: str = centralidp_config.get("clientid", None)
+    clientid: str = centralidp_config.get("client_id", None)
     if auth_url is None:
         raise Exception("[INIT] No centralidp clientid config was specified!")
 
-    clientsecret: str = centralidp_config.get("clientsecret", None)
+    clientsecret: str = centralidp_config.get("client_secret", None)
     if auth_url is None:
         raise Exception("[INIT] No centralidp clientsecret config was specified!")
 
     #### [KEYCLOAK AUTH CHECK] [START] ------
-
     try:
         idpManager = IdpManager(auth_url=auth_url, clientid=clientid, clientsecret=clientsecret, realm=realm)
         logger.info("[INIT] Sucessfully connected to the centralidp server!")
     except Exception as e:
         logger.critical("[INIT] The authentication service has failed! Reason: %s", str(e))
-
-    if idpManager is None:
-        raise Exception(
-            "[INIT] The application was not able to connect to the central idp server, with the provided credentials!")
 
     discovery_config: dict = app_configuration.get("discovery", None)
     if discovery_config is None:

--- a/IndustryFlagService/backend/service/edcService.py
+++ b/IndustryFlagService/backend/service/edcService.py
@@ -65,7 +65,7 @@ class EdcService:
     TRANSFER_ID_KEY = "transferProcessId"
     NEGOTATION_ID_KEY = "contractNegotiationId"
 
-    def __init__(self, config: dict, auth_instance: SovityAuth):
+    def __init__(self, config: dict):
         """
         Initializes the EDC (Eclipse Datapace Connector) Service with the provided configuration.
 
@@ -83,12 +83,8 @@ class EdcService:
             raise Exception("[EDC Service] The BPN or participantId is required in the configuration!")
 
         ## Get all the variables
-        self.auth_instance = auth_instance
         oauth_config = config.get('oauth', {})
-        token_url = oauth_config.get('token_url')
-        client_id = oauth_config.get('client_id')
-        client_secret = oauth_config.get('client_secret')
-        self.bearer_token = self.auth_instance.get_edc_token(token_url, client_id, client_secret)
+        self.apiKey = oauth_config.get("apiKey")
         self.consumer_endpoint = config.get('url')
         self.participant_id = config.get("participantId")
 
@@ -180,7 +176,7 @@ class EdcService:
         ## Build the headers needed for the edc the app to communicate with the edc control plane
         return {
             # self.auth_key: self.api_key,
-            "Authorization": f"Bearer {self.bearer_token}",
+            "X-Api-Key": f"{self.apiKey}",
             "Content-Type": "application/json"
         }
 


### PR DESCRIPTION
## Description
This PR fixes the initial configuration of the Industry Flag Service, which was preventing the service from starting up or functioning as expected. The configuration parameters have been reviewed and corrected to ensure reliable deployment and behavior.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
