### PR TITLE
Added docker build-and-push workflows

### DIFF
--- a/.github/workflows/dt-pull-service-build.yml
+++ b/.github/workflows/dt-pull-service-build.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=main
             type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image

--- a/.github/workflows/ifs-build.yml
+++ b/.github/workflows/ifs-build.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.BACKEND_IMAGE_NAME }}
           tags: |
-            type=raw,value=main
             type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image
@@ -96,7 +95,6 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.FRONTEND_IMAGE_NAME }}
           tags: |
-            type=raw,value=main
             type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image

--- a/.github/workflows/test-orchestrator-build.yml
+++ b/.github/workflows/test-orchestrator-build.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=main
             type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->


The following docker build workflows are required to publish images to the dockerhub registry:

- ifs-backend, ifs-frontend
- dt-pull-service
- test-orchestrator
 
The further details are described in https://github.com/eclipse-tractusx/tractusx-sdk-services/issues/7

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
