### PR TITLE
Fix: Fixed the validation in the get_dtr_access function to ensure a DTR asset is returned by the catalog

### DIFF
--- a/test-orchestrator/test_orchestrator/api/base_test_cases.py
+++ b/test-orchestrator/test_orchestrator/api/base_test_cases.py
@@ -106,20 +106,18 @@ async def dtr_ping_test(counter_party_address: str,
      - :return: A dictionary containing a success or an error message.
     """
 
-    try:
-        dataplane_url, dtr_key, _ = await get_dtr_access(
+    dataplane_url, dtr_key, _ = await get_dtr_access(
                 counter_party_address,
                 counter_party_id,
                 operand_left='http://purl.org/dc/terms/type',
                 operand_right='%https://w3id.org/catenax/taxonomy#DigitalTwinRegistry%',
                 limit=1)
-
+    try:
+        
         shell_descriptors = await make_request('GET',
                                                f'{config.DT_PULL_SERVICE_ADDRESS}/dtr/shell-descriptors/',
-                                               params={'dataplane_url': dataplane_url, 'limit': 1},
-                                               headers = get_dt_pull_service_headers(headers={'Authorization': dtr_key}),
-                                               timeout=60
-                                               )
+                                               params={'dataplane_url': dataplane_url},
+                                               headers = {'Authorization': dtr_key})
     except HTTPError:
         raise HTTPError(
             Error.CONNECTION_FAILED,

--- a/test-orchestrator/test_orchestrator/utils.py
+++ b/test-orchestrator/test_orchestrator/utils.py
@@ -109,6 +109,15 @@ async def get_dtr_access(counter_party_address: str,
                                               'limit': limit},
                                       headers=get_dt_pull_service_headers())
 
+    # Validate if there is a DTR offer available
+    if len(catalog_json["dcat:dataset"]) == 0:
+        raise HTTPError(
+            Error.CONTRACT_NEGOTIATION_FAILED,
+            message='There were no offers for the digital twin registry found in this connectors catalog. ' + \
+                    'Either the properties or access policy of the DTR asset are misconfigured.',
+            details='Please check https://eclipse-tractusx.github.io/docs-kits/kits/digital-twin-kit/' + \
+                    'software-development-view/#digital-twin-registry-as-edc-data-asset for troubleshooting.')
+
     # Validate result of the policy from the catalog if required
     policy_validation_outcome = validate_policy(catalog_json)
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR fixes the "internal server error" that the testbed returns for /dtr-ping-test/, /shell-descriptors-test/ or /submodel-test/ when there is no DTR offer available in the specified connector. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #22 

Now the testbed returns a proper error message: 

<img width="1452" height="1115" alt="image" src="https://github.com/user-attachments/assets/8b32cd21-c70f-4269-a3be-d6f0d901e99e" />


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
