### PR TITLE
[Fix] Fixed a missing DT_Pull auth header and added a limit to the DTR catalog call

### DIFF
--- a/test-orchestrator/test_orchestrator/api/base_test_cases.py
+++ b/test-orchestrator/test_orchestrator/api/base_test_cases.py
@@ -120,8 +120,8 @@ async def dtr_ping_test(counter_party_address: str,
         
         shell_descriptors = await make_request('GET',
                                                f'{config.DT_PULL_SERVICE_ADDRESS}/dtr/shell-descriptors/',
-                                               params={'dataplane_url': dataplane_url},
-                                               headers = {'Authorization': dtr_key},
+                                               params={'dataplane_url': dataplane_url, 'limit': 1},
+                                                headers=get_dt_pull_service_headers(headers={'Authorization': dtr_key}),
                                                timeout=timeout)
     except HTTPError:
         raise HTTPError(


### PR DESCRIPTION
Update base_test_cases.py: Fixed missing DT_Pull auth header and added a limit to the DTR ping-test /shell-descriptor call to not fetch too many digital twins.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixes an error introduced in the last PR that removed the DT_Pull auth header in the dtr ping test. Also added a ?limit=1 parameter to the GET /shell-descriptor call for the ping test so that the service doesn't try to fetch all digital twins in the registry. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
