### PR TITLE
[Fix] Append $value to the request against the dataplane

### DIFF
--- a/test-orchestrator/test_orchestrator/api/industry_test_cases.py
+++ b/test-orchestrator/test_orchestrator/api/industry_test_cases.py
@@ -262,13 +262,14 @@ async def submodel_test(counter_party_address: str,
             policy_validation=False
             )
 
-        # Run the submodels request pointed at the href link
-        response = httpx.get(submodel_info['href'], headers={'Authorization': dtr_key_subm})
+        # Run the submodels request pointed at the href link. To comply with industry core standards, the testbed appends $value.
+        response = httpx.get(submodel_info['href']+'/$value', headers={'Authorization': dtr_key_subm})
 
         if response.status_code != 200:
             raise HTTPError(Error.UNPROCESSABLE_ENTITY,
-                            message='Failed to obtain the required submodel',
-                            details={'href': submodel_info['href']})
+                            message=f'Make sure your dataplane can resolve the request and that the href above ' +\
+                                    'is according to the industry core specification, ending in /submodel.',
+                            details=f'Failed to obtain the required submodel data for({submodel_info['href']}).')
 
         try:
             submodels = response.json()


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
According to the industry core KIT, an 'href' must end on /submodel and then the consumer has to add /$value to fetch the data. This was currently missing in the testbed. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
