### PR TITLE
[FIX] Makes the response message more generic in case there aren't any offers found

### DIFF
--- a/test-orchestrator/test_orchestrator/utils.py
+++ b/test-orchestrator/test_orchestrator/utils.py
@@ -112,14 +112,16 @@ async def get_dtr_access(counter_party_address: str,
                                       timeout=timeout,
                                       headers=get_dt_pull_service_headers())
 
-    # Validate if there is a DTR offer available
+    # Validate if there is an offer for the desired asset/type available. 
     if len(catalog_json["dcat:dataset"]) == 0:
         raise HTTPError(
             Error.CONTRACT_NEGOTIATION_FAILED,
-            message='There were no offers for the digital twin registry found in this connectors catalog. ' + \
-                    'Either the properties or access policy of the DTR asset are misconfigured.',
-            details='Please check https://eclipse-tractusx.github.io/docs-kits/kits/digital-twin-kit/' + \
-                    'software-development-view/#digital-twin-registry-as-edc-data-asset for troubleshooting.')
+            message='In case of the Digital Twin Registry Asset please check ' + \
+                    'https://eclipse-tractusx.github.io/docs-kits/kits/digital-twin-kit/' + \
+                    'software-development-view/#digital-twin-registry-as-edc-data-asset for troubleshooting.',
+            details=f'There were no offers of type/id {operand_right} found in this connectors catalog. ' + \
+                    'Either the properties or access policy of the asset are misconfigured.')
+
 
     # Validate result of the policy from the catalog if required
     policy_validation_outcome = validate_policy(catalog_json)


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

The function "get_dtr_access" is not only used to get access to the DTR but also to other assets. One would need to refactor the whole function to work as "get_asset_access". The quick fix for now allows for a more generic error response message. In case the access to the DTR works but then afterwards the asset that's defined in a submodel can't be found in the catalogue, the testbed now returns a more appropriate error message. 


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
