### PR TITLE
fix: Cert-Cases were not working correctly

### DIFF
--- a/test-orchestrator/test_orchestrator/api/cert_validation.py
+++ b/test-orchestrator/test_orchestrator/api/cert_validation.py
@@ -248,7 +248,7 @@ async def feedback_mechanism_validation(counter_party_address: str,
              dependencies=[Depends(verify_auth)])
 async def validate_certificate(payload: Dict,
                                semantic_id: Optional[str] = SEMANTIC_ID_BUSINESS_PARTNER_CERTIFICATE,
-                               contract_reference: bool = True,
+                               contract_reference: bool = False,
                                timeout: int = 80):
     """
     This test case validates if a certificate that is given as input conforms with the latest

--- a/test-orchestrator/test_orchestrator/app.py
+++ b/test-orchestrator/test_orchestrator/app.py
@@ -25,7 +25,9 @@
 
 import logging
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
+
+from fastapi.security import APIKeyHeader
 
 from test_orchestrator.api import base_test_cases, cert_validation, industry_test_cases
 from test_orchestrator.errors import (
@@ -36,6 +38,7 @@ from test_orchestrator.errors import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 
 async def health():
@@ -59,6 +62,14 @@ def create_app():
 
     :return: The FastAPI application instance.
     """
+    api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
+
+    async def get_api_key(api_key_header: str = Depends(api_key_header)):
+        if api_key_header != "dein_schluessel":
+            raise HTTPException(status_code=401)
+        return api_key_header
+    async def secure_endpoint(key: str = Depends(get_api_key)):
+        return {"status": "ok"}
 
     logger.info('Starting of the Test orchestrator application...')
 
@@ -66,7 +77,9 @@ def create_app():
                   description="This application is used for testing  " +
                               "Catena-X access",
                   contact={'name': 'Dénes Surman (dddenes)',
-                           'email': 'surmandenes@yahoo.com'})
+                           'email': 'surmandenes@yahoo.com'},
+                           swagger_ui_parameters={})
+
 
     app.add_exception_handler(HTTPError, http_error_handler)
     app.add_exception_handler(ValidationException, validation_exception_handler)

--- a/test-orchestrator/test_orchestrator/utils.py
+++ b/test-orchestrator/test_orchestrator/utils.py
@@ -127,6 +127,7 @@ async def get_dtr_access(counter_party_address: str,
 
 
     # Validate result of the policy from the catalog if required
+
     policy_validation_outcome = validate_policy(catalog_json)
 
     if policy_validation:


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR fixes a couple of issues with the cert-test-cases:
- Missing DT-Pull Service Auth Headers for Cert-Cases
- Wrong default value "contract reference" that leads to wrong default behaviour: Having a contract reference should always be an addition and not the default
- Testbed could not fetch the right default message json schema for feedbackmessage-validation testcase.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
