### PR TITLE
feat: Remove redundant variable `proceed` in traceability test error handling

### DIFF
--- a/test-orchestrator/test_orchestrator/api/traceability_test.py
+++ b/test-orchestrator/test_orchestrator/api/traceability_test.py
@@ -154,7 +154,6 @@ async def traceability_test(
             except HTTPError as e:
                 asset_result['status'] = 'failed'
                 add_step('validate_policy', 'failed', str(e), getattr(e, 'details', None))
-                proceed = False
             except Exception as e:
                 asset_result['status'] = 'failed'
                 add_step('validate_policy', 'failed', f'Unexpected error: {e}')


### PR DESCRIPTION
## Description
Updated so that checks are done even if the validation of the policies gives a warning for the traceability use case.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
