### PR TITLE
fix: get_catalog response handling in test orchestrator utils

### DIFF
--- a/.github/workflows/docker-build-dt-pull-service.yml
+++ b/.github/workflows/docker-build-dt-pull-service.yml
@@ -69,7 +69,7 @@ jobs:
           images:
             ${{ matrix.image }}
             # Automatically prepare image tags;
-          # semver patter will generate tags like these for example :1 :1.2
+            # semver patter will generate tags like these for example :1 :1.2
           tags: |
             type=raw,value=latest
             type=raw,value=${{ github.ref_name }}


### PR DESCRIPTION
## Description
- Rename `catalog_json` to `catalog_response` for clarity.
- Extract `response_json` from `catalog_response` for improved readability.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
