### PR TITLE
[Fix] Added missing code to enable PCF test cases

### DIFF
--- a/dt-pull-service/dt_pull_service/models.py
+++ b/dt-pull-service/dt_pull_service/models.py
@@ -518,7 +518,7 @@ class DtrHandler:
 
         self.partner_dtr_addr = partner_dtr_address
         self.partner_dtr_secret = partner_dtr_secret
-        self.proxies = {'http': proxy, 'https': proxy} if proxy != '' else {}
+        self.proxies = {'http': proxy, 'https': proxy} if proxy else None
 
     def get_all_shells(self, limit:int=None) -> list | None:
         """
@@ -640,7 +640,7 @@ class DtrHandler:
         :raises HTTPError: Raised if the request encounters errors such as authentication issues,
                            server unavailability, or unknown errors.
         """
-
+        print("HERE")
         headers = {
             'Authorization': self.partner_dtr_secret
         }

--- a/dt-pull-service/dt_pull_service/models.py
+++ b/dt-pull-service/dt_pull_service/models.py
@@ -640,7 +640,6 @@ class DtrHandler:
         :raises HTTPError: Raised if the request encounters errors such as authentication issues,
                            server unavailability, or unknown errors.
         """
-        print("HERE")
         headers = {
             'Authorization': self.partner_dtr_secret
         }

--- a/test-orchestrator/test_orchestrator/api/product_carbon_footprint.py
+++ b/test-orchestrator/test_orchestrator/api/product_carbon_footprint.py
@@ -35,8 +35,40 @@ from test_orchestrator.utils.product_carbon_footprint import (
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+@router.get('/create-pcf-request/{manufacturer_part_id}',
+            response_model=Dict,
+            dependencies=[Depends(verify_auth)])
+async def create_pcf_request(manufacturer_part_id: str = Path(..., description='Manufacturer Part ID'),
+                          counter_party_id: str = Query(..., description="Counter party ID"),
+                          counter_party_address: str =
+                            Query(..., description="The DSP endpoint address of the supplier's connector"),
+                          pcf_version: Literal['7.0.0', '8.0.0', '9.0.0']  =
+                            Query('8.0.0', description='Schema version - 7.0.0 or 8.0.0 supported'),
+                          timeout: int = 80,
+                          cache: CacheProvider = Depends(get_cache_provider)):
+    """This test-case initiates the PCF exchange by negotiating access to the partners PCF asset,
+    create a pcf request and send it to the test subjects PCF endpoint via its EDC connector.
+    
+    Args:
+        manufacturer_part_id: Manufacturer part identifier
+        counter_party_id: Supplier's Business Partner Number
+        counter_party_address: Supplier's EDC DSP endpoint
+        pcf_version: PCF schema version (7.0.0 or 8.0.0)
+        timeout: Request timeout in seconds
+        cache: Cache provider dependency
+    
+    Returns:
+        Dict with status, manufacturerPartId, requestId, and offer information
+    """
+    return await pcf_check(manufacturer_part_id=manufacturer_part_id,
+                           counter_party_id=counter_party_id,
+                           counter_party_address=counter_party_address,
+                           pcf_version=pcf_version,
+                           request_id=None,
+                           timeout=timeout,
+                           cache=cache)
 
-@router.get('/productIds/{manufacturer_part_id}',
+@router.get('/request-pcf-response/{manufacturer_part_id}',
             response_model=Dict,
             dependencies=[Depends(verify_auth)])
 async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Manufacturer Part ID'),
@@ -44,9 +76,8 @@ async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Man
                           counter_party_address: str =
                             Query(..., description="The DSP endpoint address of the supplier's connector"),
                           pcf_version: Literal['7.0.0', '8.0.0', '9.0.0']  =
-                            Query('8.0.0', description='Schema version - 7.0.0 or 8.0.0 supported'),
-                          edc_bpn_l: str = Header(..., alias='Edc-Bpn-L'),
-                          request_id: Optional[str] = Query(None, description='Optional Request ID'),
+                            Query('9.0.0', description='Schema version - 7.0.0 or 8.0.0 supported'),
+                          request_id: str = Query(..., description='Request ID'),
                           timeout: int = 80,
                           cache: CacheProvider = Depends(get_cache_provider)):
     """Retrieve Product Carbon Footprint offer from supplier's Digital Twin Registry.
@@ -59,7 +90,6 @@ async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Man
         counter_party_id: Supplier's Business Partner Number
         counter_party_address: Supplier's EDC DSP endpoint
         pcf_version: PCF schema version (7.0.0 or 8.0.0)
-        edc_bpn_l: Requester's Business Partner Number (from header)
         request_id: Optional request ID for tracking
         timeout: Request timeout in seconds
         cache: Cache provider dependency
@@ -71,7 +101,6 @@ async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Man
                            counter_party_id=counter_party_id,
                            counter_party_address=counter_party_address,
                            pcf_version=pcf_version,
-                           edc_bpn_l=edc_bpn_l,
                            request_id=request_id,
                            timeout=timeout,
                            cache=cache)
@@ -80,25 +109,25 @@ async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Man
 @router.put('/productIds/{manufacturer_part_id}',
             response_model=Dict,
             dependencies=[Depends(verify_auth)])
-async def update_product_pcf(manufacturer_part_id: str = Path(..., description='Manufacturer Part ID'),
+async def update_product_pcf(payload: Dict,
+                             manufacturer_part_id: str = Path(..., description='Manufacturer Part ID'),
                              request_id: str = Query(..., description='Request ID from previous GET call'),
-                             edc_bpn: str = Header(..., alias='Edc-Bpn'),
-                             cache: CacheProvider = Depends(get_cache_provider)):
+                             cache: CacheProvider = Depends(get_cache_provider)):   
     """Validate incoming PCF data update from supplier.
 
     This endpoint receives PCF data from the supplier and validates it against
-    the previously cached request information from the GET call.
+    the previously cached request information from the GET call. The endpoint has to be
+    exposed via an EDC Asset.
 
     Args:
         manufacturer_part_id: Manufacturer part identifier
         requestId: Request ID from the initial GET request
-        edc_bpn: Supplier's Business Partner Number (from header)
         cache: Cache provider dependency
 
     Returns:
         Dict with validation status, message, requestId, and manufacturerPartId
     """
-    return await validate_pcf_update(manufacturer_part_id=manufacturer_part_id,
+    return await validate_pcf_update(payload=payload,
+                                     manufacturer_part_id=manufacturer_part_id,
                                      request_id=request_id,
-                                     edc_bpn=edc_bpn,
                                      cache=cache)

--- a/test-orchestrator/test_orchestrator/api/product_carbon_footprint.py
+++ b/test-orchestrator/test_orchestrator/api/product_carbon_footprint.py
@@ -112,6 +112,8 @@ async def get_product_pcf(manufacturer_part_id: str = Path(..., description='Man
 async def update_product_pcf(payload: Dict,
                              manufacturer_part_id: str = Path(..., description='Manufacturer Part ID'),
                              request_id: str = Query(..., description='Request ID from previous GET call'),
+                            pcf_version: Literal['7.0.0', '8.0.0', '9.0.0']  =
+                            Query('9.0.0', description='Schema version - 7.0.0 or 8.0.0 supported'),
                              cache: CacheProvider = Depends(get_cache_provider)):   
     """Validate incoming PCF data update from supplier.
 
@@ -130,4 +132,5 @@ async def update_product_pcf(payload: Dict,
     return await validate_pcf_update(payload=payload,
                                      manufacturer_part_id=manufacturer_part_id,
                                      request_id=request_id,
+                                     pcf_version=pcf_version,
                                      cache=cache)

--- a/test-orchestrator/test_orchestrator/checks/request_catalog.py
+++ b/test-orchestrator/test_orchestrator/checks/request_catalog.py
@@ -77,7 +77,7 @@ async def get_catalog(
                         message=message,
                         details=details)
 
-    logger.info("Catalog JSON received: %s", catalog_json)
+    logger.info("Catalog JSON received: %s", str(catalog_json)[:200])
 
     # Validate if there is an offer for the desired asset/type available.
     if len(catalog_json["dcat:dataset"]) == 0:

--- a/test-orchestrator/test_orchestrator/request_handler.py
+++ b/test-orchestrator/test_orchestrator/request_handler.py
@@ -48,13 +48,20 @@ async def make_request(method: str, url: str, timeout:int=80, **kwargs):
     async with httpx.AsyncClient() as client:
         try:
             response = await client.request(method, url, timeout=timeout, **kwargs)
+            
+
             try:
                 response_json = response.json()
             except ValueError as e:
-                logger.error(f'Invalid JSON response from {url}: {e} - {response.content}')
-                raise HTTPError(Error.BAD_GATEWAY,
-                                message='Received invalid JSON from server',
-                                details=str(e)) from e
+
+                # Some APIs may not return JSON on success (e.g., 204 No Content or 200 with bytestring or empty body)
+                if response.status_code == 200 or response.status_code == 204:
+                    return {"status": "success"}
+                else:
+                    logger.error(f'Invalid JSON response from {url}: {e} - {response.content}')
+                    raise HTTPError(Error.BAD_GATEWAY,
+                                    message='Received invalid JSON from server',
+                                    details=str(e)) from e
 
             if response.status_code != 200:
                 error_code = response_json.get('error', 'BAD_GATEWAY')

--- a/test-orchestrator/test_orchestrator/utils/product_carbon_footprint.py
+++ b/test-orchestrator/test_orchestrator/utils/product_carbon_footprint.py
@@ -279,7 +279,7 @@ async def pcf_check(
         )
 
     if not request_id:
-        print("No request_id provided, caching offer and sending GET requests.")
+        logger.info("No request_id provided, caching offer and sending GET requests.")
         await cache.set(
             requestId,
             {
@@ -298,7 +298,7 @@ async def pcf_check(
             bpn=counter_party_id,
         )
     else:
-        print("request_id provided, sending PUT request with dummy PCF data.")
+        logger.info("request_id provided, sending PUT request with dummy PCF data.")
         semanticid = f"urn:bamm:io.catenax.pcf:{pcf_version}#Pcf"
         dummy_pcf = await pcf_dummy_dataloader(semanticid)
 

--- a/test-orchestrator/test_orchestrator/utils/product_carbon_footprint.py
+++ b/test-orchestrator/test_orchestrator/utils/product_carbon_footprint.py
@@ -32,36 +32,21 @@ from test_orchestrator.auth import get_dt_pull_service_headers
 from test_orchestrator.cache import CacheProvider
 from test_orchestrator.errors import Error, HTTPError
 from test_orchestrator.request_handler import make_request
-from test_orchestrator.utils import get_dataplane_access
+from test_orchestrator.utils import get_dataplane_access, submodel_schema_finder
+from test_orchestrator.validator import json_validator
 
 logger = logging.getLogger(__name__)
 
 
-def validate_inputs(edc_bpn: str, manufacturer_part_id: str):
-    """Validate BPN and manufacturer part ID format.
+def validate_inputs(manufacturer_part_id: str):
+    """Validate manufacturer part ID format.
 
     Args:
-        edc_bpn: Business Partner Number in BPN format
         manufacturer_part_id: Manufacturer part identifier containing only alphanumeric, dash, and underscore
 
     Raises:
-        HTTPError: If edc_bpn is missing, has invalid format, or manufacturer_part_id contains invalid characters
+        HTTPError: If manufacturer_part_id contains invalid characters
     """
-    if not edc_bpn:
-        raise HTTPError(
-            Error.MISSING_REQUIRED_FIELD,
-            message="Missing required header: Edc-Bpn",
-            details="Missing header",
-        )
-
-    bpn_pattern = re.compile(r"^BPN[LSA][A-Z0-9]{10}[A-Z0-9]{2}$")
-
-    if not bpn_pattern.match(edc_bpn):
-        raise HTTPError(
-            Error.REGEX_VALIDATION_FAILED,
-            message=f"Invalid BPN: {edc_bpn}",
-            details="Invalid format",
-        )
 
     part_id_pattern = re.compile(r"^[A-Za-z0-9\-_]+$")
 
@@ -216,7 +201,7 @@ async def send_pcf_responses(
             url=url,
             timeout=timeout,
             params={"requestId": request_id},
-            headers={"Edc-Bpn": bpn, "Authorization": key},
+            headers={"Authorization": key},
         )
 
         responses["without_requestId"] = await make_request(
@@ -242,7 +227,6 @@ async def pcf_check(
     counter_party_id: str,
     counter_party_address: str,
     pcf_version: str,
-    edc_bpn_l: str,
     timeout: int,
     request_id: Optional[str] = None,
     cache: Optional[CacheProvider] = None,
@@ -274,7 +258,7 @@ async def pcf_check(
     Raises:
         HTTPError: If validation fails, DTR access fails, or PCF submodel is not found
     """
-    validate_inputs(edc_bpn_l, manufacturer_part_id)
+    validate_inputs(manufacturer_part_id)
 
     requestId = request_id if request_id else str(uuid.uuid4())
 
@@ -290,11 +274,12 @@ async def pcf_check(
     if not dataplane_url or not pcf_key:
         raise HTTPError(
             Error.CATALOG_FETCH_FAILED,
-            message="DTR access negotiation failed",
-            details="No dataplane URL or DTR key received",
+            message="PCF Exchange API access negotiation failed",
+            details="No dataplane URL or key received",
         )
 
     if not request_id:
+        print("No request_id provided, caching offer and sending GET requests.")
         await cache.set(
             requestId,
             {
@@ -310,9 +295,10 @@ async def pcf_check(
             product_id=manufacturer_part_id,
             request_id=requestId,
             timeout=timeout,
-            bpn=edc_bpn_l,
+            bpn=counter_party_id,
         )
     else:
+        print("request_id provided, sending PUT request with dummy PCF data.")
         semanticid = f"urn:bamm:io.catenax.pcf:{pcf_version}#Pcf"
         dummy_pcf = await pcf_dummy_dataloader(semanticid)
 
@@ -328,8 +314,7 @@ async def pcf_check(
             url=url,
             timeout=timeout,
             params={"requestId": requestId},
-            headers={"Edc-Bpn": config.CONNECTOR_BPNL,
-                     "Authorization": pcf_key},
+            headers={"Authorization": pcf_key},
             json=dummy_pcf,
         )
 
@@ -341,7 +326,11 @@ async def pcf_check(
 
 
 async def validate_pcf_update(
-    manufacturer_part_id: str, request_id: str, edc_bpn: str, cache: CacheProvider
+    payload: dict, 
+    manufacturer_part_id: str, 
+    request_id: str, 
+    cache: CacheProvider, 
+    pcf_version: str = "9.0.0"
 ):
     """Validate incoming PCF update request against cached data.
 
@@ -352,9 +341,8 @@ async def validate_pcf_update(
     Args:
         manufacturer_part_id: Manufacturer part identifier from request path
         requestId: Request identifier from query parameter
-        edc_bpn: Business Partner Number from request header
         cache: Cache provider instance for retrieving cached data
-
+        pcf_version: PCF schema version 
     Returns:
         Dict containing status, message, requestId, and manufacturerPartId
 
@@ -362,15 +350,8 @@ async def validate_pcf_update(
         HTTPError: If BPN format is invalid, manufacturer part ID contains invalid characters,
                   requestId not found in cache, or manufacturerPartId mismatch
     """
-    bpn_pattern = re.compile(r"^BPN[LSA][A-Z0-9]{10}[A-Z0-9]{2}$")
 
-    if not bpn_pattern.match(edc_bpn):
-        raise HTTPError(
-            Error.REGEX_VALIDATION_FAILED,
-            message=f"Invalid BPN format: {edc_bpn}",
-            details="Expected format like BPNL000000000000",
-        )
-
+    # Validate manufacturer part ID format
     manufacturerPartId_pattern = re.compile(r"^[A-Za-z0-9\-_]+$")
 
     if manufacturer_part_id and not manufacturerPartId_pattern.match(
@@ -381,7 +362,30 @@ async def validate_pcf_update(
             message="manufacturerPartId contains invalid characters",
             details="manufacturerPartId contains invalid characters",
         )
+    
+    # Validate payload against PCF schema (9.0.0 per default)
+     # Find the right schema and validate the submodels against it
+    try:
+        subm_schema_dict = submodel_schema_finder(semantic_id = f"urn:bamm:io.catenax.pcf:{pcf_version}#Pcf")
+        subm_schema = subm_schema_dict['schema']
+    except Exception:
+        raise HTTPError(
+            Error.SUBMODEL_VALIDATION_FAILED,
+            message=f'The validation of the requested submodel for semanticID {semantic_id} failed: ' + \
+                    'Could not find the submodel schema based on the semantic_id provided.',
+            details='Please check https://eclipse-tractusx.github.io/docs-kits/kits/industry-core-kit/' + \
+                    'software-development-view/aspect-models for troubleshooting and samples.')
 
+
+    schema_validation_result = json_validator(subm_schema, payload)
+    
+    
+    if not cached_data:
+        raise HTTPError(
+            Error.NOT_FOUND,
+            message=f"No cached request found for requestId: {request_id}",
+            details="The requestId may have expired or is invalid",
+        )
     cached_data = await cache.get(request_id)
 
     if not cached_data:
@@ -400,12 +404,23 @@ async def validate_pcf_update(
 
     await delete_cache_entry(request_id, cache)
 
-    return {
-        "status": "ok",
-        "message": "PCF data validated successfully",
-        "requestId": request_id,
-        "manufacturerPartId": manufacturer_part_id,
-    }
+    #Note the PCF schema is inconsistent, so we just return a warning if the schema validation fails
+    if schema_validation_result.get("status") != "ok":
+        return {
+            "status": "warning",
+            "message": "PCF request including requestID and manufacturerPartId validated successfully. "
+            "Payload schema validation failed.",
+            "requestId": request_id,
+            "manufacturerPartId": manufacturer_part_id,
+        }
+    else:
+        return {
+            "status": "ok",
+            "message": "PCF request including requestID and manufacturerPartId validated successfully. "
+            "Payload schema validation passed.",
+            "requestId": request_id,
+            "manufacturerPartId": manufacturer_part_id,
+        }
 
 
 async def delete_cache_entry(request_id: str, cache: CacheProvider):


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR completes the PCF logic introduced by https://github.com/eclipse-tractusx/tractusx-sdk-services/pull/51 by adding complete test case execution flows. 

It's missing the automated setup of the PCF asset that has to expose the PUT /pcf/productIds/ endpont. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
