### PR TITLE
Added negative test step for traceability check

### DIFF
--- a/test-orchestrator/test_orchestrator/api/traceability_test.py
+++ b/test-orchestrator/test_orchestrator/api/traceability_test.py
@@ -25,6 +25,9 @@ Provide FastAPI endpoints for data asset checks.
 
 """
 
+from __future__ import annotations
+from typing import Any
+
 from fastapi import APIRouter, Depends, Query
 
 from test_orchestrator import config
@@ -33,6 +36,7 @@ from test_orchestrator.checks.catalog_version_validation import validate_catalog
 from test_orchestrator.checks.create_notification import (
     qualitynotification_receive,
     qualitynotification_update,
+    traceability_invalid,
 )
 from test_orchestrator.checks.policy_validation import validate_policy
 from test_orchestrator.checks.request_catalog import get_catalog
@@ -325,6 +329,16 @@ async def traceability_test(
             except Exception as inner_e:
                 asset_result['status'] = 'failed'
                 add_step(step_name or 'invoke_operation', 'failed', 'Notification call failed', str(inner_e))
+                
+        # Step 8: Negative test – invalid payload (e.g. wrong header.version) must be rejected with 4xx
+        if proceed and step_name in ('invoke_receive', 'invoke_update') and asset_result['status'] == 'success':
+            await _run_negative_test(endpoint, authorization, "invoke_update_with_wrong_payload", asset_result)
+        else:
+            asset_result['steps'].append({
+                "step": "invoke_update_with_wrong_payload",
+                "status": "skipped",
+                "message": "Previous step failed or no receive/update operation"
+            })
 
         results.append(asset_result)
 
@@ -338,3 +352,45 @@ async def traceability_test(
         'message': 'CX-0125 Traceability checks completed',
         'results': results
     }
+   
+async def _run_negative_test(
+    endpoint: str,
+    authorization: str,
+    name: str,
+    asset_result: dict[str, Any]
+):
+    """Perform negative test by sending invalid payload and expecting 4xx."""
+    try:
+        result = await traceability_invalid(endpoint, authorization)
+        status_code = result.get("status_code", 0)
+        if 400 <= status_code < 500:
+            asset_result['steps'].append({
+                "step": name,
+                "status": "success",
+                "message": "Invalid payload rejected as expected",
+                "details": {"request": result.get("request"), "response": result.get("response")},
+            })
+        else:
+            asset_result["status"] = "failed"
+            asset_result['steps'].append({
+                "step": name,
+                "status": "failed",
+                "message": f"Expected 4xx for invalid payload, got {status_code}",
+                "details": result.get("response"),
+            })
+    except HTTPError as e:
+        asset_result["status"] = "failed"
+        asset_result['steps'].append({
+            "step": name,
+            "status": "failed",
+            "message": str(e),
+            "details": getattr(e, "details", None),
+        })
+    except Exception as e:
+        asset_result["status"] = "failed"
+        asset_result['steps'].append({
+            "step": name,
+            "status": "failed",
+            "message": "Negative test request failed",
+            "details": str(e),
+        })

--- a/test-orchestrator/test_orchestrator/api/traceability_test.py
+++ b/test-orchestrator/test_orchestrator/api/traceability_test.py
@@ -339,6 +339,16 @@ async def traceability_test(
                 "status": "skipped",
                 "message": "Previous step failed or no receive/update operation"
             })
+            
+        # Step 9: Negative test – invalid payload (e.g. wrong header.version) must be rejected with 4xx
+        if proceed and step_name in ('invoke_receive', 'invoke_update') and asset_result['status'] == 'success':
+            await _run_negative_test(endpoint, authorization, "invoke_update_with_wrong_payload", asset_result, payload_content_name="body")
+        else:
+            asset_result['steps'].append({
+                "step": "invoke_update_with_wrong_payload",
+                "status": "skipped",
+                "message": "Previous step failed or no receive/update operation"
+            })
 
         results.append(asset_result)
 
@@ -357,11 +367,12 @@ async def _run_negative_test(
     endpoint: str,
     authorization: str,
     name: str,
-    asset_result: dict[str, Any]
+    asset_result: dict[str, Any],
+    payload_content_name: str = "content",
 ):
     """Perform negative test by sending invalid payload and expecting 4xx."""
     try:
-        result = await traceability_invalid(endpoint, authorization)
+        result = await traceability_invalid(endpoint, authorization, content_name=payload_content_name)
         status_code = result.get("status_code", 0)
         if 400 <= status_code < 500:
             asset_result['steps'].append({

--- a/test-orchestrator/test_orchestrator/checks/create_notification.py
+++ b/test-orchestrator/test_orchestrator/checks/create_notification.py
@@ -33,7 +33,7 @@ under the key "Authorization".
 from typing import Any, Dict
 
 from test_orchestrator.logging.log_manager import LoggingManager
-from test_orchestrator.request_handler import make_request_status_only
+from test_orchestrator.request_handler import make_request_status_only, make_request_return_response
 
 __all__ = [
     "qualitynotification_receive",
@@ -134,3 +134,33 @@ async def qualitynotification_update(
     logger.info(f"Sending update notification to {endpoint} with payload: {payload}")
 
     return await make_request_status_only("POST", endpoint, headers=headers, json=payload)
+
+async def traceability_invalid(
+    endpoint: str,
+    authorization: str
+) -> dict:
+    headers = {
+        "Authorization": authorization,
+        "Content-Type": "application/json",
+    }
+    
+    payload = {
+        "header": {
+            "messageId": "41d743c3-6e8a-4393-88af-10494e50bea9",
+            "context": "Traceability-QualityNotification-Investigation:2.0.0",
+            "sentDateTime": "2025-03-04T10:00:00+00:00",
+            "senderBpn": "BPNL0000000000AA",
+            "receiverBpn": "BPNL1111111111BB",
+        },
+        "content": {
+            "notificationId": "41d743c3-6e8a-4393-88af-10494e50bea9",
+            "status": "SENT",
+            "severity": "CRITICAL",
+            "listOfAffectedItems": [
+            "urn:uuid:57e4e3c1-a6f0-46a0-90df-1fb17cbc157d"
+            ]
+        }
+    }
+
+    
+    return await make_request_return_response("POST", endpoint, headers=headers, json=payload)

--- a/test-orchestrator/test_orchestrator/checks/create_notification.py
+++ b/test-orchestrator/test_orchestrator/checks/create_notification.py
@@ -137,7 +137,8 @@ async def qualitynotification_update(
 
 async def traceability_invalid(
     endpoint: str,
-    authorization: str
+    authorization: str,
+    content_name: str = "content"
 ) -> dict:
     headers = {
         "Authorization": authorization,
@@ -151,7 +152,7 @@ async def traceability_invalid(
             "senderBpn": "12i31jl3j21ihjkul",
             "receiverBpn": "ahsdjfhjskdhfjklsd",
         },
-        "content": {
+        content_name: {
             "notificationId": "41d743c3-6e8a-4393-88af-10494e50bea9",
             "listOfAffectedItems": [
             "urn:uuid:57e4e3c1-a6f0-46a0-90df-1fb17cbc157d"

--- a/test-orchestrator/test_orchestrator/checks/create_notification.py
+++ b/test-orchestrator/test_orchestrator/checks/create_notification.py
@@ -147,15 +147,12 @@ async def traceability_invalid(
     payload = {
         "header": {
             "messageId": "41d743c3-6e8a-4393-88af-10494e50bea9",
-            "context": "Traceability-QualityNotification-Investigation:2.0.0",
             "sentDateTime": "2025-03-04T10:00:00+00:00",
-            "senderBpn": "BPNL0000000000AA",
-            "receiverBpn": "BPNL1111111111BB",
+            "senderBpn": "12i31jl3j21ihjkul",
+            "receiverBpn": "ahsdjfhjskdhfjklsd",
         },
         "content": {
             "notificationId": "41d743c3-6e8a-4393-88af-10494e50bea9",
-            "status": "SENT",
-            "severity": "CRITICAL",
             "listOfAffectedItems": [
             "urn:uuid:57e4e3c1-a6f0-46a0-90df-1fb17cbc157d"
             ]

--- a/test-orchestrator/test_orchestrator/request_handler.py
+++ b/test-orchestrator/test_orchestrator/request_handler.py
@@ -310,3 +310,54 @@ async def make_request_status_only(method: str, url: str, timeout: int = 80, **k
                 message='An unknown error occurred while performing the request',
                 details=str(e),
             ) from e
+
+
+async def make_request_return_response(method: str, url: str, timeout: int = 80, **kwargs) -> dict:
+    """
+    Makes an HTTP request and returns status code and IO metadata without raising on non-2xx.
+    Use for negative tests where 4xx is expected. Network/connection errors still raise HTTPError.
+
+    :param method: HTTP method (e.g., 'POST')
+    :param url: The request URL
+    :param timeout: Timeout in seconds. Default is 80.
+    :param kwargs: Additional arguments forwarded to httpx.request
+    :return: Dict with status_code, request, response, response_json
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.request(method, url, timeout=timeout, **kwargs)
+            sent_request = response.request if hasattr(response, 'request') else None
+            request_info = {
+                'method': getattr(sent_request, 'method', method) if sent_request else method,
+                'url': str(getattr(sent_request, 'url', url)) if sent_request else url,
+                'headers': dict(getattr(sent_request, 'headers', {})) if sent_request else {},
+                'content': None
+            }
+            try:
+                if sent_request and getattr(sent_request, 'content', None) is not None:
+                    request_info['content'] = sent_request.content.decode('utf-8', errors='ignore')
+            except Exception:
+                pass
+            response_info = {
+                'status_code': response.status_code,
+                'headers': dict(response.headers),
+                'text': response.text,
+            }
+            parsed_json = None
+            try:
+                parsed_json = response.json()
+            except ValueError:
+                parsed_json = None
+            return {
+                'status_code': response.status_code,
+                'request': request_info,
+                'response': response_info,
+                'response_json': parsed_json,
+            }
+        except (httpx.TimeoutException, httpx.ConnectError, httpx.RequestError) as e:
+            logger.error(f'Request to {url} failed: {e}')
+            raise HTTPError(
+                Error.BAD_GATEWAY,
+                message=f'Request failed: {e}',
+                details=str(e),
+            ) from e


### PR DESCRIPTION
## Description
Added a negative test step for the traceability checks.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ x ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ x ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
